### PR TITLE
OverridableMapping now writes in an upper scratch layer

### DIFF
--- a/tests/test_ubimaior.py
+++ b/tests/test_ubimaior.py
@@ -170,21 +170,45 @@ class TestAllMappings(object):
 
         mapping_nc['foo'] = 11
         assert mapping_nc['foo'] == 11
-        assert mapping_nc.mappings['highest']['foo'] == 11
-        assert mapping_nc.mappings['middle']['foo'] == 6
+
+        # OverridableMapping uses a top layer to override
+        # the overall result in the view
+        if isinstance(mapping_nc, ubimaior.OverridableMapping):
+            assert mapping_nc.mappings[
+                ubimaior.OverridableMapping.scratch_key
+            ]['foo:'] == 11
+
+        # MergedMapping instead writes directly in the input mappings
+        if isinstance(mapping_nc, ubimaior.MergedMapping):
+            assert mapping_nc.mappings['highest']['foo'] == 11
+            assert mapping_nc.mappings['middle']['foo'] == 6
 
         mapping_nc['bar'] = 'overwritten'
         assert mapping_nc['bar'] == 'overwritten'
-        assert 'bar' not in mapping_nc.mappings['highest']
-        assert mapping_nc.mappings['middle']['bar'] == 'overwritten'
-        assert mapping_nc.mappings['lowest']['bar'] == '4'
+
+        if isinstance(mapping_nc, ubimaior.OverridableMapping):
+            assert mapping_nc.mappings[
+                ubimaior.OverridableMapping.scratch_key
+            ]['bar:'] == 'overwritten'
+
+        if isinstance(mapping_nc, ubimaior.MergedMapping):
+            assert 'bar' not in mapping_nc.mappings['highest']
+            assert mapping_nc.mappings['middle']['bar'] == 'overwritten'
+            assert mapping_nc.mappings['lowest']['bar'] == '4'
 
         assert 'baz' not in mapping_nc.mappings['middle']
         mapping_nc['baz'] = True
         assert mapping_nc['baz'] is True
-        assert 'baz' not in mapping_nc.mappings['highest']
-        assert mapping_nc.mappings['middle']['baz'] is True
-        assert mapping_nc.mappings['lowest']['baz'] is False
+
+        if isinstance(mapping_nc, ubimaior.OverridableMapping):
+            assert mapping_nc.mappings[
+                ubimaior.OverridableMapping.scratch_key
+            ]['baz:'] is True
+
+        if isinstance(mapping_nc, ubimaior.MergedMapping):
+            assert 'baz' not in mapping_nc.mappings['highest']
+            assert mapping_nc.mappings['middle']['baz'] is True
+            assert mapping_nc.mappings['lowest']['baz'] is False
 
         with pytest.raises(TypeError) as excinfo:
             mapping_nc['foo'] = 'a_string'

--- a/tests/test_ubimaior.py
+++ b/tests/test_ubimaior.py
@@ -110,7 +110,7 @@ def mapping_d():
 
 
 @pytest.fixture()
-def overridable():
+def overridable_l():
     """An instance of a merged mapping, with list values."""
     highest_priority = {
         'foo': [11, 22],
@@ -138,6 +138,30 @@ def overridable():
     return merged
 
 
+@pytest.fixture()
+def overridable_d():
+    """An instance of a merged mapping, with list values."""
+    highest_priority = {
+        'foo': {'a': 1, 'b': {'xx': 1}},
+    }
+
+    middle_priority = {
+        'foo:': {'c': 2},
+    }
+
+    lowest_priority = {
+        'foo': {'d': 3},
+    }
+
+    merged = ubimaior.OverridableMapping([
+        ('highest', highest_priority),
+        ('middle', middle_priority),
+        ('lowest', lowest_priority)
+    ])
+
+    return merged
+
+
 class TestAllMappings(object):
     def test_errors_on_init(self, mapping_type):
         # not a list
@@ -149,11 +173,6 @@ class TestAllMappings(object):
         with pytest.raises(TypeError) as excinfo:
             mapping_type([1, 2, 3])
         assert 'items in "mappings" should be' in str(excinfo.value)
-
-        # one or more mapping is needed
-        with pytest.raises(ValueError) as excinfo:
-            mapping_type([])
-        assert '"mappings" should contain one or more' in str(excinfo.value)
 
     def test_reading_non_container_types(self, mapping_nc):
 
@@ -234,6 +253,12 @@ class TestAllMappings(object):
 
 
 class TestMergedMapping(object):
+
+    def test_errors_on_init(self):
+        # one or more mapping is needed
+        with pytest.raises(ValueError) as excinfo:
+            ubimaior.MergedMapping([])
+        assert '"mappings" should contain one or more' in str(excinfo.value)
 
     def test_reading_lists(self, mapping_l):
         assert mapping_l['foo'][:] == [1, 11, 111]
@@ -551,6 +576,74 @@ class TestMergedSequence(object):
 
 
 class TestOverridableMapping(object):
-    def test_reading_containers(self, overridable):
+    def test_reading_lists(self, overridable_l):
+        # foo is overridden
+        assert list(overridable_l['foo']) == [11, 22, 'a', 'b']
 
-        assert list(overridable['foo']) == [11, 22, 'a', 'b']
+        # bar and baz should behave as MergedSequence
+        assert list(overridable_l['baz']) == [1, 2, 3, 4, 5, 6]
+        assert list(overridable_l['bar']) == ['a', 'b']
+
+    @pytest.mark.xfail
+    def test_views_are_immutable(self, overridable_l):
+        # FIXME: this should return an immutable sequence, instead
+        # FIXME: of a mutable one
+        with pytest.raises(AttributeError):
+            overridable_l['foo'].append(1)
+
+        with pytest.raises(TypeError):
+            overridable_l['foo'][0] = 2
+
+        with pytest.raises(TypeError):
+            del overridable_l['foo'][0]
+
+    def test_setting_lists(self, overridable_l):
+
+        overridable_l['foo'] = [1, 2, 3]
+
+        assert list(overridable_l['foo']) == [1, 2, 3]
+        assert overridable_l.scratch['foo:'] == [1, 2, 3]
+        assert overridable_l.highest['foo'] == [11, 22]
+
+    def test_setting_dicts(self, overridable_d):
+
+        assert dict(overridable_d['foo'].items()) == {
+            'a': 1,
+            'b': {'xx': 1},
+            'c': 2
+        }
+        # Getting a key creates an empty dictionary in scratch
+        assert overridable_d.scratch['foo'] == {'b': {}}
+
+        # Setting nested keys
+        overridable_d['foo']['c'] = 4
+        # assert overridable_d.scratch
+        assert dict(overridable_d['foo'].items()) == {
+            'a': 1,
+            'b': {'xx': 1},
+            'c': 4
+        }
+        assert overridable_d.scratch['foo'] == {'b': {}, 'c:': 4}
+
+        overridable_d['foo'] = {'a': 1}
+        assert dict(overridable_d['foo'].items()) == {'a': 1}
+        assert overridable_d.highest['foo'] == {'a': 1, 'b': {'xx': 1}}
+
+    def test_using_invalid_keys(self, overridable_d):
+
+        with pytest.raises(TypeError) as excinfo:
+            key = (1, 2)
+            overridable_d[key] = None
+        msg = str(excinfo.value)
+        assert 'unsupported key type' in msg
+
+        with pytest.raises(TypeError) as excinfo:
+            key = (1, 2)
+            overridable_d[key]
+        msg = str(excinfo.value)
+        assert 'unsupported key type' in msg
+
+        with pytest.raises(ValueError) as excinfo:
+            overridable_d['foo:'] = None
+        msg = str(excinfo.value)
+        assert 'a key cannot end with a' in msg

--- a/ubimaior/ubimaior.py
+++ b/ubimaior/ubimaior.py
@@ -24,19 +24,9 @@ def _is_tuple_str_mapping(obj):
         isinstance(obj[0], str) and isinstance(obj[1], MutableMapping)
 
 
-class MergedMapping(MutableMapping):  # pylint: disable=too-many-ancestors
-    """Shows a list of mappings with different levels of priority as
-    they were a single one.
-
-    TODO: write something about merging and write rules
-
-    FIXME: Is this implementable in terms of collections.ChainMap?
-    """
-
-    #: Caches the setting of the preferred scope
-    _preferred_scope = None
-
-    def __init__(self, mappings, preferred_scope=None):
+# pylint: disable=too-few-public-methods,abstract-method
+class _MappingBase(MutableMapping):
+    def __init__(self, mappings):
         # Check the type of mappings, which should be a list of
         # (str, Mapping) tuples
         if not isinstance(mappings, list):
@@ -57,6 +47,95 @@ class MergedMapping(MutableMapping):  # pylint: disable=too-many-ancestors
         #: Ordered dict that contains the priority list
         #: of mappings
         self.mappings = collections.OrderedDict(mappings)
+
+    def __iter__(self):
+        return iter(self._get_merged_keys())
+
+    def __len__(self):
+        return len(self._get_merged_keys())
+
+    def _get_merged_keys(self):
+        """Returns the list of merged keys, ensuring a partial ordering
+        (all the keys of the first item come before the second, etc.)
+
+        Returns:
+            list of keys
+        """
+        seen_keys = set()
+
+        def seen(k):
+            """Returns True if 'k' was already seen, False otherwise"""
+            res = k in seen_keys
+            seen_keys.add(k)
+            return res
+
+        return [
+            k for d in self.mappings.values() for k in d.keys() if not seen(k)
+        ]
+
+    def _type_for_key_or_raise(self, key):
+        """Returns the type associated with a given key.
+
+        Args:
+            key: key to be searched
+
+        Returns:
+            type of the value (must be consistent among all
+            the managed mappings) or None if ``key not in self``
+
+        Raises:
+            TypeError: if more than one type is associated with the key
+        """
+        # If the key is present in multiple mappings, and holds
+        # instances of different types raise a TypeError
+        types_for_mapping = {
+            scope: type(v[key])
+            for scope, v in self.mappings.items() if key in v
+        }
+        if len(set(types_for_mapping.values())) > 1:
+            msg = 'type mismatch for key "{0}".'
+            msg += ' Overridden keys need to be of the same type.'
+            raise TypeError(msg.format(key))
+
+        if types_for_mapping:
+            return next(iter(types_for_mapping.values()))
+
+        return None
+
+    def __delitem__(self, key):
+        # Deleting a type means deleting it from every managed scope
+        for _, mapping in self.mappings.items():
+            if key in mapping:
+                del mapping[key]
+
+
+def _convert_to_type_or_raise(current_type, key, value):
+    if current_type != type(value) and current_type is not None:
+        try:
+            value = current_type(value)
+        except Exception:
+            msg = 'cannot assign value of type {0} to key "{1}"'
+            msg += '[{0} is not convertible to {2}]'
+            raise TypeError(msg.format(
+                type(value).__name__, key, current_type.__name__
+            ))
+    return value
+
+
+class MergedMapping(_MappingBase):  # pylint: disable=too-many-ancestors
+    """Shows a list of mappings with different levels of priority as
+    they were a single one.
+
+    TODO: write something about merging and write rules
+
+    FIXME: Is this implementable in terms of collections.ChainMap?
+    """
+
+    #: Caches the setting of the preferred scope
+    _preferred_scope = None
+
+    def __init__(self, mappings, preferred_scope=None):
+        super(MergedMapping, self).__init__(mappings)
         self.preferred_scope = preferred_scope
 
     def __getitem__(self, key):
@@ -88,15 +167,7 @@ class MergedMapping(MutableMapping):  # pylint: disable=too-many-ancestors
 
         # Check that the type of value is compatible with
         current_type = self._type_for_key_or_raise(key)
-        if current_type != type(value) and current_type is not None:
-            try:
-                value = current_type(value)
-            except Exception:
-                msg = 'cannot assign value of type {0} to key "{1}"'
-                msg += '[{0} is not convertible to {2}]'
-                raise TypeError(msg.format(
-                    type(value).__name__, key, current_type.__name__
-                ))
+        value = _convert_to_type_or_raise(current_type, key, value)
 
         # If I want to set a list or dictionary to be exactly
         # what is passed in, then I need to delete what's already
@@ -106,37 +177,6 @@ class MergedMapping(MutableMapping):  # pylint: disable=too-many-ancestors
 
         scope = self._get_writing_scope(key)
         self.mappings[scope][key] = value
-
-    def __delitem__(self, key):
-        # Deleting a type means deleting it from every managed scope
-        for _, mapping in self.mappings.items():
-            if key in mapping:
-                del mapping[key]
-
-    def __iter__(self):
-        return iter(self._get_merged_keys())
-
-    def __len__(self):
-        return len(self._get_merged_keys())
-
-    def _get_merged_keys(self):
-        """Returns the list of merged keys, ensuring a partial ordering
-        (all the keys of the first item come before the second, etc.)
-
-        Returns:
-            list of keys
-        """
-        seen_keys = set()
-
-        def seen(k):
-            """Returns True if 'k' was already seen, False otherwise"""
-            res = k in seen_keys
-            seen_keys.add(k)
-            return res
-
-        return [
-            k for d in self.mappings.values() for k in d.keys() if not seen(k)
-        ]
 
     def _get_writing_scope(self, key):
         for scope, item in self.mappings.items():
@@ -149,35 +189,6 @@ class MergedMapping(MutableMapping):  # pylint: disable=too-many-ancestors
                     self.preferred_scope == scope or \
                     key in item:
                 return scope
-        return None
-
-    def _type_for_key_or_raise(self, key):
-        """Returns the type associated with a given key.
-
-        Args:
-            key: key to be searched
-
-        Returns:
-            type of the value (must be consistent among all
-            the managed mappings) or None if ``key not in self``
-
-        Raises:
-            TypeError: if more than one type is associated with the key
-        """
-        # If the key is present in multiple mappings, and holds
-        # instances of different types raise a TypeError
-        types_for_mapping = {
-            scope: type(v[key])
-            for scope, v in self.mappings.items() if key in v
-        }
-        if len(set(types_for_mapping.values())) > 1:
-            msg = 'type mismatch for key "{0}".'
-            msg += ' Overridden keys need to be of the same type.'
-            raise TypeError(msg.format(key))
-
-        if types_for_mapping:
-            return next(iter(types_for_mapping.values()))
-
         return None
 
     @property
@@ -404,8 +415,16 @@ class MergedSequence(MutableSequence):  # pylint: disable=too-many-ancestors
         return values
 
 
-class OverridableMapping(MergedMapping):  # pylint: disable=too-many-ancestors
+class OverridableMapping(_MappingBase):  # pylint: disable=too-many-ancestors
     """A MergedMapping with some rules to override keys in the hierarchy."""
+
+    scratch_key = '_scratch_'
+
+    def __init__(self, mappings):
+        super(OverridableMapping, self).__init__(mappings)
+        self.mappings = collections.OrderedDict(
+            [(self.scratch_key, {})] + mappings
+        )
 
     def __getitem__(self, key):
         # Check that we don't have more than one key once we applied the
@@ -434,12 +453,27 @@ class OverridableMapping(MergedMapping):  # pylint: disable=too-many-ancestors
         if not values:
             raise KeyError(key)
 
-        first_value = values[0][1]
+        first_scope, first_value = values[0]
 
         if isinstance(first_value, MutableMapping):
+            # If we get to a nested dictionary
+            if first_scope != self.scratch_key:
+                self.mappings[self.scratch_key][key] = {}
+
             return OverridableMapping(values)
 
         if isinstance(first_value, MutableSequence):
             return MergedSequence([value for _, value in values])
 
         return first_value
+
+    def __setitem__(self, key, value):
+        # Compute the key and its corresponding override
+        key, override_key = key.rstrip(':'), key.rstrip(':') + ':'
+        override_key_type = self._type_for_key_or_raise(override_key)
+        current_type = override_key_type or self._type_for_key_or_raise(key)
+
+        # Normalize the value or raise
+        value = _convert_to_type_or_raise(current_type, key, value)
+
+        self.mappings[self.scratch_key][override_key] = value


### PR DESCRIPTION
The strategy in `OverridableMapping` has been changed to write in an upper scratch layer (in a similar way with respect to what is done in the upper layer of a union filesystem).

The implementation details of `MergedMapping` and `OverridableMapping` have been refactored to reduce code duplication. Tests have been adapted to the new logic.

Still missing:
- [x] unit tests on `OverridableMapping` that set collections