### PR TITLE
Display provenance of each entry in a merged configuration

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ coverage==4.5.2
 Sphinx==1.7.6
 jsonschema==2.6.0
 click==7.0
-
+enum34==1.1.6; python_version < '3.4'
 PyYAML==3.13
 toml==0.10.0
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'six',
     'jsonschema',
-    'Click'
+    'Click',
+    'enum34 ; python_version<"3.4"',
 ]
 
 setup_requirements = [

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -61,3 +61,15 @@ def test_show_blame(runner, working_dir, data_dir, fmt):
             ubimaior.commands.main, ['--format={0}'.format(fmt), 'show', '--blame', 'config_nc']
         )
         assert result.exit_code == 0
+
+
+def test_output_is_valid(runner, working_dir, data_dir, fmt, monkeypatch):
+    with working_dir(data_dir):
+        result = runner.invoke(
+            ubimaior.commands.main, ['--format={0}'.format(fmt), 'show', 'config_nc']
+        )
+        decoder = getattr(ubimaior.formats, fmt)
+        obj = decoder.loads(result.output) if fmt != 'yaml' else decoder.load(result.output)
+
+        assert all(key in obj for key in ('foo', 'nested', 'bar', 'baz'))
+        assert obj['nested']['a'] == [1, 2, 3, 4, 5, 6]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -10,6 +10,11 @@ def runner():
     return click.testing.CliRunner()
 
 
+@pytest.fixture(params=ubimaior.formats.FORMATTERS)
+def fmt(request):
+    return request.param
+
+
 def test_showing_help(runner, working_dir, data_dir):
     result = runner.invoke(ubimaior.commands.main, ['--help'])
     assert result.exit_code == 0
@@ -20,7 +25,6 @@ def test_showing_help(runner, working_dir, data_dir):
         assert result.exit_code == 0
 
 
-@pytest.mark.parametrize('fmt', ubimaior.formats.FORMATTERS)
 def test_show_all_formats(runner, working_dir, data_dir, fmt):
     with working_dir(data_dir):
         result = runner.invoke(
@@ -47,5 +51,13 @@ def test_validate_configurations(runner, working_dir, data_dir):
         result = runner.invoke(
             ubimaior.commands.main,
             ['--configuration=.ubimaior.json', 'show', '--validate', 'config_nc']
+        )
+        assert result.exit_code == 0
+
+
+def test_show_blame(runner, working_dir, data_dir, fmt):
+    with working_dir(data_dir):
+        result = runner.invoke(
+            ubimaior.commands.main, ['--format={0}'.format(fmt), 'show', '--blame', 'config_nc']
         )
         assert result.exit_code == 0

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -435,3 +435,9 @@ class TestOverridableMapping(object):
         flattened = overridable_d.flattened(target='middle')
         assert flattened['babau'] == 1
         assert 'babau' in flattened.middle
+
+    def test_getting_scopes(self, overridable_d):
+        scopes = overridable_d.get_scopes('foo')
+        assert scopes == ['highest', 'middle']
+
+        assert overridable_d.get_scopes('bar') is None

--- a/ubimaior/commands.py
+++ b/ubimaior/commands.py
@@ -63,8 +63,11 @@ def show(validate, blame, name):
         ubimaior.configurations.validate(cfg, schema)
 
     formatter = ubimaior.formats.FORMATTERS[settings.format]
-    styles = collections.defaultdict(lambda: lambda x: click.style(x, bold=True))
-    styles[ubimaior.formats.TokenTypes.ATTRIBUTE] = lambda x: click.style(x, fg='yellow', bold=True)
+    styles = None
+    if settings.format in {'yaml', 'json'}:
+        styles = collections.defaultdict(lambda: lambda x: click.style(x, bold=True))
+        attribute = ubimaior.formats.TokenTypes.ATTRIBUTE
+        styles[attribute] = lambda x: click.style(x, fg='yellow', bold=True)
 
     cfg_lines, provenance = formatter.pprint(cfg, formatters=styles)
 

--- a/ubimaior/commands.py
+++ b/ubimaior/commands.py
@@ -96,11 +96,11 @@ def format_provenance(provenance):
     scopes = [
         click.style('[[', bold=True) +
         ','.join(click.style(x, fg=color_map[x]) for x in scope) +
-        click.style(']]', bold=True) + '    '
+        click.style(']]', bold=True) + '  '
         for scope in provenance
     ]
 
     raw_lengths = [len(','.join(x)) for x in provenance]
     max_width = max(raw_lengths)
     spaces_to_add = [max_width - x for x in raw_lengths]
-    return [val + ' '*spacer for val, spacer in zip(scopes, spaces_to_add)]
+    return [val + ' '*spacer + '|' for val, spacer in zip(scopes, spaces_to_add)]

--- a/ubimaior/formats.py
+++ b/ubimaior/formats.py
@@ -9,8 +9,8 @@ import json
 # so we are relying on an external substitute for Python 2.7
 try:
     import enum
-except ImportError:
-    import enum34 as enum
+except ImportError:  # pragma: no cover
+    import enum34 as enum  # pragma: no cover
 
 import six
 
@@ -261,10 +261,8 @@ try:
             yaml.dump(obj, stream)
 
         def format_token(self, token, indent_block, format_fn):
-            if token.line is None:
-                return None
+            line = None if token.line is None else format_fn(str(token.line))
 
-            line = format_fn(str(token.line))
             if token.obj_type == TokenTypes.ATTRIBUTE:
                 return indent_block*token.indent_lvl + line + ':'
             if token.obj_type == TokenTypes.LIST_ITEM:
@@ -272,7 +270,7 @@ try:
             if token.obj_type == TokenTypes.VALUE:
                 return indent_block*token.indent_lvl + line
 
-            return None
+            return line
 
 except ImportError:  # pragma: no cover
     pass  # pragma: no cover

--- a/ubimaior/formats.py
+++ b/ubimaior/formats.py
@@ -3,6 +3,7 @@
 
 import abc
 import collections
+import json
 
 # The module enum does not exist for Python < 3.4,
 # so we are relying on an external substitute for Python 2.7
@@ -10,8 +11,6 @@ try:
     import enum
 except ImportError:
     import enum34 as enum
-
-import json
 
 import six
 
@@ -65,6 +64,8 @@ class PrettyPrinter(six.with_metaclass(abc.ABCMeta, object)):
         """
         # Tokenize the object to be printed
         tokens = _tokenize_object(obj)
+        if tokens:
+            tokens[-1] = tokens[-1]._replace(continuation=False)
 
         # Construct a representation for each token
         formatters = formatters or collections.defaultdict(lambda: lambda x: x)
@@ -72,8 +73,9 @@ class PrettyPrinter(six.with_metaclass(abc.ABCMeta, object)):
         cfg_lines, cfg_scopes = [], []
         for token in tokens:
             current = self.format_token(token, indent_block, formatters[token.obj_type])
-            cfg_lines.append(current)
-            cfg_scopes.append(token.scope or [])
+            if current:
+                cfg_lines.append(current)
+                cfg_scopes.append(token.scope or [])
 
         return cfg_lines, cfg_scopes
 
@@ -125,47 +127,76 @@ def formatter(name, attribute=None):
 
 
 _Token = collections.namedtuple('Token', [
-    'line', 'scope', 'indent_lvl', 'obj_type'
+    'line', 'scope', 'indent_lvl', 'obj_type', 'continuation'
 ])
 
 
 class TokenTypes(enum.Enum):
     """Enumerate the token types used to display merged mappings."""
+    #: Start a dictionary
+    DICTIONARY_START = 0
     #: An attribute in a dictionary
     ATTRIBUTE = 1
+    #: End a dictionary
+    DICTIONARY_END = 2
+    # Start a list
+    LIST_START = 3
     #: An item in a list
-    LIST_ITEM = 2
+    LIST_ITEM = 4
+    # End a list
+    LIST_END = 5
     #: A scalar Value
-    VALUE = 3
+    VALUE = 6
 
 
 def _tokenize_object(obj, scope=None, indent_lvl=0):
     tokens = []
     if isinstance(obj, ubimaior.OverridableMapping):
+        tokens.append(_Token(
+            line=None, scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.DICTIONARY_START,
+            continuation=False
+        ))
         for attribute, value in obj.items():
             scope = obj.get_scopes(attribute)
             # scope = [sc for sc, m in obj.mappings.items() if attribute in m]
             tokens.append(_Token(
                 line=str(attribute), scope=scope, indent_lvl=indent_lvl,
-                obj_type=TokenTypes.ATTRIBUTE
+                obj_type=TokenTypes.ATTRIBUTE, continuation=False
             ))
             # Descend on the current value
             tokens.extend(_tokenize_object(value, scope=scope, indent_lvl=indent_lvl+1))
 
+        # Here we are closing the dictionary, so there's no further object
+        tokens[-1] = tokens[-1]._replace(continuation=False)
+        tokens.append(_Token(
+            line=None, scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.DICTIONARY_END,
+            continuation=True
+        ))
+
     elif isinstance(obj, ubimaior.MergedSequence):
         assert len(scope) == len(obj.sequences), 'unexpected number of scopes'
-
+        tokens.append(_Token(
+            line=None, scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.LIST_START,
+            continuation=False
+        ))
         for component_scope, component_list in zip(scope, obj.sequences):
             for value in component_list:
                 tokens.append(_Token(
-                    line=str(value), scope=[component_scope], indent_lvl=indent_lvl + 1,
-                    obj_type=TokenTypes.LIST_ITEM
+                    line=value, scope=[component_scope], indent_lvl=indent_lvl + 1,
+                    obj_type=TokenTypes.LIST_ITEM, continuation=True
                 ))
+
+        tokens[-1] = tokens[-1]._replace(continuation=False)
+        tokens.append(_Token(
+            line=None, scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.LIST_END,
+            continuation=True
+        ))
 
     else:
         assert len(scope) == 1, 'expected a single scope for a scalar value'
         tokens.append(_Token(
-            line=str(obj), scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.VALUE
+            line=obj, scope=scope, indent_lvl=indent_lvl, obj_type=TokenTypes.VALUE,
+            continuation=True
         ))
 
     return tokens
@@ -181,13 +212,38 @@ class JsonFormatter(Dumper, Loader, PrettyPrinter):
         json.dump(obj, stream)
 
     def format_token(self, token, indent_block, format_fn):
-        line = format_fn(token.line)
-        if token.obj_type == TokenTypes.ATTRIBUTE:
+
+        start_or_end_marker = {
+            TokenTypes.DICTIONARY_START,
+            TokenTypes.DICTIONARY_END,
+            TokenTypes.LIST_START,
+            TokenTypes.LIST_END
+        }
+
+        line = '' if token.obj_type in start_or_end_marker else format_fn(json.dumps(token.line))
+
+        if token.obj_type == TokenTypes.DICTIONARY_START:
+            line += token.indent_lvl * indent_block + '{'
+
+        elif token.obj_type == TokenTypes.DICTIONARY_END:
+            line += token.indent_lvl * indent_block + '}'
+
+        elif token.obj_type == TokenTypes.LIST_START:
+            line += token.indent_lvl * indent_block + '['
+
+        elif token.obj_type == TokenTypes.LIST_END:
+            line += token.indent_lvl * indent_block + ']'
+
+        elif token.obj_type == TokenTypes.ATTRIBUTE:
             line = indent_block * token.indent_lvl + line + ':'
+
         elif token.obj_type == TokenTypes.LIST_ITEM:
-            line = (token.indent_lvl - 1) * indent_block + '- ' + line
+            line = token.indent_lvl * indent_block + line
         else:
             line = indent_block * token.indent_lvl + line
+
+        if token.continuation:
+            line += ','
 
         return line
 
@@ -205,15 +261,18 @@ try:
             yaml.dump(obj, stream)
 
         def format_token(self, token, indent_block, format_fn):
-            line = format_fn(token.line)
-            if token.obj_type == TokenTypes.ATTRIBUTE:
-                line = indent_block*token.indent_lvl + line + ':'
-            elif token.obj_type == TokenTypes.LIST_ITEM:
-                line = (token.indent_lvl-1)*indent_block + '- ' + line
-            else:
-                line = indent_block*token.indent_lvl + line
+            if token.line is None:
+                return None
 
-            return line
+            line = format_fn(str(token.line))
+            if token.obj_type == TokenTypes.ATTRIBUTE:
+                return indent_block*token.indent_lvl + line + ':'
+            if token.obj_type == TokenTypes.LIST_ITEM:
+                return (token.indent_lvl-1)*indent_block + '- ' + line
+            if token.obj_type == TokenTypes.VALUE:
+                return indent_block*token.indent_lvl + line
+
+            return None
 
 except ImportError:  # pragma: no cover
     pass  # pragma: no cover
@@ -225,21 +284,65 @@ try:
     @formatter('toml', attribute='TOML')
     class TomlFormatter(Dumper, Loader, PrettyPrinter):
         """Formatter for TOML"""
+
+        def __init__(self):
+            #: Keeps track of which attributes need to
+            #: be prepended to a given key = value pair
+            self._token_stack = []
+            #: Whether we started pprinting or not
+            self._pprint_started = False
+            #: Cache for the current attribute
+            self._current_attribute = None
+
         def load(self, stream):
             return toml.load(stream)
 
         def dump(self, obj, stream):
             toml.dump(obj, stream)
 
-        def format_token(self, token, indent_block, format_fn):
-            line = format_fn(token.line)
-            if token.obj_type == TokenTypes.ATTRIBUTE:
-                line = indent_block*token.indent_lvl + line + ':'
-            elif token.obj_type == TokenTypes.LIST_ITEM:
-                line = (token.indent_lvl-1)*indent_block + '- ' + line
-            else:
-                line = indent_block*token.indent_lvl + line
+        @property
+        def current_key(self):
+            """Returns the key that is being analyzed"""
+            return '.'.join([str(x.line) for x in self._token_stack] +
+                            [str(self._current_attribute.line)])
 
+        def format_token(self, token, indent_block, format_fn):
+            # TOML only accept objects as root, The following lines start / finish
+            # a parsing sequence
+            if token.obj_type == TokenTypes.DICTIONARY_START and not self._pprint_started:
+                self._pprint_started = True
+                return None
+            if token.obj_type == TokenTypes.DICTIONARY_END and not self._token_stack:
+                self._pprint_started = False
+                return None
+
+            assert self._pprint_started, 'unexpected event during formatting.'
+
+            # Operations that modify the cached attributes
+            if token.obj_type == TokenTypes.ATTRIBUTE:
+                self._current_attribute = token
+                return None
+            if token.obj_type == TokenTypes.DICTIONARY_START:
+                self._token_stack.append(self._current_attribute)
+                self._current_attribute = None
+                return None
+            if token.obj_type == TokenTypes.DICTIONARY_END:
+                self._current_attribute = self._token_stack.pop()
+                return None
+
+            # Operations that return formatted output
+            line = None
+            if token.obj_type == TokenTypes.LIST_START:
+                key, self._current_attribute = self.current_key, None
+                line = '{0} = ['.format(key)
+            elif token.obj_type == TokenTypes.LIST_END:
+                line = ']'
+            elif token.obj_type == TokenTypes.LIST_ITEM:
+                line = indent_block*token.indent_lvl + repr(token.line) + \
+                       (',' if token.continuation else '')
+            elif token.obj_type == TokenTypes.VALUE:
+                key, self._current_attribute = self.current_key, None
+                line = '{0} = {1}'.format(key, token.line)
             return line
 
 except ImportError:  # pragma: no cover

--- a/ubimaior/formats.py
+++ b/ubimaior/formats.py
@@ -337,7 +337,7 @@ try:
             elif token.obj_type == TokenTypes.LIST_ITEM:
                 line = indent_block*token.indent_lvl + repr(token.line) + \
                        (',' if token.continuation else '')
-            elif token.obj_type == TokenTypes.VALUE:
+            elif token.obj_type == TokenTypes.VALUE:  # pragma: no cover
                 value = str(token.line)
                 if isinstance(token.line, bool):
                     value = value.lower()

--- a/ubimaior/formats.py
+++ b/ubimaior/formats.py
@@ -64,8 +64,7 @@ class PrettyPrinter(six.with_metaclass(abc.ABCMeta, object)):
         """
         # Tokenize the object to be printed
         tokens = _tokenize_object(obj)
-        if tokens:
-            tokens[-1] = tokens[-1]._replace(continuation=False)
+        tokens[-1] = tokens[-1]._replace(continuation=False)
 
         # Construct a representation for each token
         formatters = formatters or collections.defaultdict(lambda: lambda x: x)
@@ -339,8 +338,13 @@ try:
                 line = indent_block*token.indent_lvl + repr(token.line) + \
                        (',' if token.continuation else '')
             elif token.obj_type == TokenTypes.VALUE:
+                value = str(token.line)
+                if isinstance(token.line, bool):
+                    value = value.lower()
+                elif isinstance(token.line, six.string_types):
+                    value = '"' + value + '"'
                 key, self._current_attribute = self.current_key, None
-                line = '{0} = {1}'.format(key, token.line)
+                line = '{0} = {1}'.format(key, value)
             return line
 
 except ImportError:  # pragma: no cover

--- a/ubimaior/mappings.py
+++ b/ubimaior/mappings.py
@@ -495,12 +495,15 @@ class OverridableMapping(_MappingBase):  # pylint: disable=too-many-ancestors
         Returns:
             list of scopes or None
         """
-        _, values = self._get_key_components(key)
+        try:
+            _, values = self._get_key_components(key)
 
-        if values:
-            first_scope, first_value = values[0]
-            if not isinstance(first_value, (MutableMapping, MutableSequence)):
-                return [first_scope]
-            return [s for s, v in values if v]
+            if values:
+                first_scope, first_value = values[0]
+                if not isinstance(first_value, (MutableMapping, MutableSequence)):
+                    return [first_scope]
+                return [s for s, v in values if v]
+        except KeyError:
+            pass
 
         return None


### PR DESCRIPTION
fixes #39 

An option has been added to `ubimaior show` to display the provenance of each entry. This information is currently shown using the scope's mnemonic names:
```console
$  ubimaior show --blame config_nc
[[highest]]           foo:
[[highest]]             1
[[highest,lowest]]    nested:
[[highest,lowest]]      a:
[[highest]]               - 1
[[highest]]               - 2
[[highest]]               - 3
[[lowest]]                - 4
[[lowest]]                - 5
[[lowest]]                - 6
[[lowest]]              b:
[[lowest]]                True
[[middle]]            bar:
[[middle]]              this_is_bar
[[lowest]]            baz:
[[lowest]]              False
```

**Formats**
- [x] JSON
- [x] YAML
- [x] TOML